### PR TITLE
Fix var naming from verb to noun

### DIFF
--- a/step5.7-makeYourOwnAdventure-incomplete/MYOA-Data-Driven/MYOA/Connection.swift
+++ b/step5.7-makeYourOwnAdventure-incomplete/MYOA-Data-Driven/MYOA/Connection.swift
@@ -12,10 +12,10 @@ import Foundation
 struct Connection {
     
     var prompt: String
-    var connectToStoryNodeNamed: String
+    var connectedStoryNodeName: String
     
     init(dictionary: [String : String]) {
         prompt = dictionary["prompt"]!
-        connectToStoryNodeNamed = dictionary["connectTo"]!
+        connectedStoryNodeName = dictionary["connectTo"]!
     }
 }

--- a/step5.7-makeYourOwnAdventure-incomplete/MYOA-Data-Driven/MYOA/StoryNode.swift
+++ b/step5.7-makeYourOwnAdventure-incomplete/MYOA-Data-Driven/MYOA/StoryNode.swift
@@ -27,7 +27,7 @@ struct StoryNode {
     // The Story node that corresponds to the prompt with the same index.
     
     func storyNodeForIndex(index: Int) -> StoryNode {
-        let storyNodeName = connections[index].connectToStoryNodeNamed
+        let storyNodeName = connections[index].connectedStoryNodeName
         let storyNode = adventure.storyNodes[storyNodeName]
         
         return storyNode!

--- a/step5.8-makeYourOwnAdventure-complete/MYOA-Data-Driven/MYOA/Connection.swift
+++ b/step5.8-makeYourOwnAdventure-complete/MYOA-Data-Driven/MYOA/Connection.swift
@@ -12,10 +12,10 @@ import Foundation
 struct Connection {
     
     var prompt: String
-    var connectToStoryNodeNamed: String
+    var connectedStoryNodeName: String
     
     init(dictionary: [String : String]) {
         prompt = dictionary["prompt"]!
-        connectToStoryNodeNamed = dictionary["connectTo"]!
+        connectedStoryNodeName = dictionary["connectTo"]!
     }
 }

--- a/step5.8-makeYourOwnAdventure-complete/MYOA-Data-Driven/MYOA/StoryNode.swift
+++ b/step5.8-makeYourOwnAdventure-complete/MYOA-Data-Driven/MYOA/StoryNode.swift
@@ -27,7 +27,7 @@ struct StoryNode {
     // The Story node that corresponds to the prompt with the same index.
     
     func storyNodeForIndex(index: Int) -> StoryNode {
-        let storyNodeName = connections[index].connectToStoryNodeNamed
+        let storyNodeName = connections[index].connectedStoryNodeName
         let storyNode = adventure.storyNodes[storyNodeName]
         
         return storyNode!


### PR DESCRIPTION
This commit changes the variable name in the Connections and StoryNode struct from
connectToStoryNodeNamed to connectedStoryNodeName as to avoid confusion
of variables and method names. As a new Swift learner, I had to do a
double take of the code to realize that a method wasn't being called in
the StoryNode class. It is common practice to use verbs for method names
so a verb named variable can cause confusion.
